### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Installation
 
 ```bash
-elm install samhstn/format-time
+elm install samhstn/time-format
 ```
 
 ### Documentation


### PR DESCRIPTION
The install instructions in the README have time and format the wrong way round leading to a confusing error.